### PR TITLE
35th import from backend

### DIFF
--- a/src/main/java/com/theironyard/controllers/FarmersMarketController.java
+++ b/src/main/java/com/theironyard/controllers/FarmersMarketController.java
@@ -285,6 +285,13 @@ public class FarmersMarketController {
             orders.delete(order);
         }
 
+        List<Order> saveOrderList = orders.findByIsPendingApprovalAndInventory(false, inventories.findOne(id));
+
+        for(Order order : saveOrderList) {
+            order.setInventory(null);
+            orders.save(order);
+        }
+
         inventories.delete(id);
     }
 

--- a/src/main/java/com/theironyard/entities/Inventory.java
+++ b/src/main/java/com/theironyard/entities/Inventory.java
@@ -1,6 +1,11 @@
 package com.theironyard.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
+import java.util.List;
 
 /**
  * Created by drewmunnerlyn on 4/8/16.

--- a/src/test/java/com/theironyard/FarmersMarketApplicationTests.java
+++ b/src/test/java/com/theironyard/FarmersMarketApplicationTests.java
@@ -286,21 +286,29 @@ public class FarmersMarketApplicationTests {
         Assert.assertTrue(orders.count() == 1);
     }
 
-//    -authorizeOrderByFarmerOrAdmin (PUT route: /orders/authorize/{id})
+    @Test
+    public void testB6authorizeOrderByFarmerOrAdmin() throws Exception { //(PUT route: /orders/authorize/{id})
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.put("/orders/authorize/2")
+                        .sessionAttr("userName", "Alice")
+        );
+        Assert.assertTrue(!orders.findOne(2).isPendingApproval());
+    }
 
 
 
     @Test
-    public void testB6DeleteInventoryUser() throws Exception { //(DELETE route: /inventory/{id})
+    public void testB7DeleteInventoryUser() throws Exception { //(DELETE route: /inventory/{id})
         mockMvc.perform(
                 MockMvcRequestBuilders.delete("/inventory/2")
                         .sessionAttr("userName", "Alice")
         );
-        Assert.assertTrue(inventories.findByUser(users.findByUserName("Alice")).size() == 1);
+        Assert.assertTrue(inventories.findByUser(users.findByUserName("Alice")).size() == 1 && orders.count() == 1);
     }
 
     @Test
-    public void testB7DeleteInventoryAdmin() throws Exception { //(DELETE route: /inventory/{id})
+    public void testB8DeleteInventoryAdmin() throws Exception { //(DELETE route: /inventory/{id})
         mockMvc.perform(
                 MockMvcRequestBuilders.delete("/inventory/3")
                         .sessionAttr("userName", "Admin")
@@ -311,14 +319,5 @@ public class FarmersMarketApplicationTests {
 //    -getOrderHistoryForFarmer *
 //    -getOderHistoryForBuyer *
 //    -logout (POST route: /logout)
-//    -deleteUserDeniedByAdmin (DELETE route: /users/{id})
-
-//     @Test
-//    public void test#DeleteUserDeniedByAdmin() throws Exception { //(DELETE route: /users/{id})
-//        mockMvc.perform(
-//                MockMvcRequestBuilders.delete("/users/2")
-//        );
-//        Assert.assertTrue(users.count() == 1);
-//    }
 
 }


### PR DESCRIPTION
35th import from backend.
to fix the test for deleting a pending order, we added logic to the inventory delete route that made the inventory object null after the isPendingApproval was changed to false (i.e. no longer pending and we just want it in order history)